### PR TITLE
Use cl-fad instead of temporary-file

### DIFF
--- a/qbase64-test.lisp
+++ b/qbase64-test.lisp
@@ -1,7 +1,7 @@
 (in-package #:cl-user)
 
 (defpackage #:qbase64-test
-  (:use #:cl #:fiveam #:temporary-file)
+  (:use #:cl #:fiveam #:cl-fad)
   (:import-from #:qbase64 #:bytes #:make-byte-vector))
 
 (in-package #:qbase64-test)

--- a/qbase64.asd
+++ b/qbase64.asd
@@ -13,7 +13,7 @@
                (:file "qbase64")))
 
 (asdf:defsystem "qbase64/test"
-  :depends-on ("qbase64" "fiveam" "temporary-file")
+  :depends-on ("qbase64" "fiveam" "cl-fad")
   :perform (test-op (o s)
                     (uiop:symbol-call :fiveam '#:run!
                                       (list (uiop:find-symbol* '#:encoder '#:qbase64-test)


### PR DESCRIPTION
temporary-file has been merged into cl-fad, but sadly the old package
name wasn't preserved, so we need to change a few things.

See also https://github.com/edicl/cl-fad/commit/1f2fd07ffc273ad720f9ef6e48b3536b21355c6b